### PR TITLE
bump version lcobucci/jwt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "league/oauth2-client": "^2.4.1",
-        "lcobucci/jwt": "^3.4.5"
+        "lcobucci/jwt": "^4.1.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
lcobucci/jwt 3.4.5 does not support PHP 8. 
lcobucci/jwt 4.1.4 supports PHP 8.